### PR TITLE
try a newer cmake

### DIFF
--- a/tasks/packages_yum.yml
+++ b/tasks/packages_yum.yml
@@ -17,7 +17,7 @@
     - kernel-devel
     - python
     - python-devel
-    - cmake
+    - cmake28
     - ccache
     - rpmdevtools
 


### PR DESCRIPTION
This should be in EPEL judging by https://dl.fedoraproject.org/pub/epel/5/x86_64/

cc @staticfloat dunno if you're still offline... I managed to cause a failure on the centos 5 buildbots by bumping libgit2, there's an issue linking openssl:

```
/home/centos/local/lib/gcc/i686-pc-linux-gnu/5.1.0/../../../../i686-pc-linux-gnu/bin/ld: CMakeFiles/libgit2_clar.dir/src/openssl_stream.c.o: undefined reference to symbol 'X509_NAME_get_entry'
/lib/libcrypto.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

Luckily it looks like this is only while building libgit2's test executable, the library itself links okay so the next build succeeds, but would still be good to fix. I think the problem is missing `-lcrypto` on the link line, probably because old cmake has a version of `FindOpenSSL` that doesn't include that. Maybe the cmake 2.8.11.2 from epel will handle it better?
